### PR TITLE
Supports a globally-installed nvm with user installs

### DIFF
--- a/templates/default/nvm.sh.erb
+++ b/templates/default/nvm.sh.erb
@@ -1,1 +1,3 @@
+export NVM_DIR="$HOME"/.nvm
+test -d "$NVM_DIR" || mkdir "$NVM_DIR"
 . <%= node['nvm']['directory'] %>/nvm.sh


### PR DESCRIPTION
This change allows a globally-installed NVM to be used by non-root users. It sets NVM_PATH to install to ~/.nvm, while NVM itself is installed to /usr/local/src/nvm.
The cookbook's LWRP to install node versions will still install to the global /usr/local/src directory. For a regular user to use the system installed packages, they must export NVM_DIR=/usr/local/src/nvm and source /usr/local/src/nvm/nvm.sh again, or explicitly update PATH=/usr/local/src/nvm/[v0.10.24]/bin and NODE_PATH=/usr/local/src/nvm/[v0.10.24]/lib/node_modules
